### PR TITLE
Fix rendering full names with IDs for formid elements

### DIFF
--- a/scripts/renderer.py
+++ b/scripts/renderer.py
@@ -326,7 +326,7 @@ class HTMLRenderer():
                                         if id == None:
                                             p.td(fullStr, class_='text', colspan=2)
                                         else:
-                                            p.td(id, class_='textid', width="15%")
+                                            p.td(str(id), class_='textid', width="15%")
                                             p.td(fullStr, class_='text')
 
                             elif sselem.type == ElementValueType.LString:


### PR DESCRIPTION
`id` is an integer in this context, which causes the HTML renderer to error.

The solution is simple once the cause was located, simply explicitly convert `id` to a string.
